### PR TITLE
Change pagination UX to show current and max page number

### DIFF
--- a/app/components/HackerNewsList/HackerNewsList.scss
+++ b/app/components/HackerNewsList/HackerNewsList.scss
@@ -6,6 +6,10 @@
   }
 }
 
+.HackerNewsList__noti {
+  text-align: center;
+}
+
 .HackerNewsList__item {
   margin: 30px 0;
 }

--- a/app/components/HackerNewsList/HackerNewsList.spec.jsx
+++ b/app/components/HackerNewsList/HackerNewsList.spec.jsx
@@ -40,4 +40,9 @@ describe('<HackerNewsList />', () => {
     const wrapper = shallow(<HackerNewsList feeds={feeds} />);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should have .HackerNewsList__noti when have no items', () => {
+    const wrapper = shallow(<HackerNewsList feeds={Immutable.List()} isFetching={false} />);
+    expect(wrapper.find('.HackerNewsList__noti')).toHaveLength(1);
+  });
 });

--- a/app/components/HackerNewsList/HackerNewsList.stories.jsx
+++ b/app/components/HackerNewsList/HackerNewsList.stories.jsx
@@ -13,7 +13,9 @@ stories
       {story()}
     </MemoryRouter>
   ))
-  .add('default', () => (
+  .add('fetching data', () => <HackerNewsList isFetching />)
+  .add('no data', () => <HackerNewsList feeds={Immutable.List()} isFetching={false} />)
+  .add('with data', () => (
     <HackerNewsList
       feeds={Immutable.fromJS([
         {

--- a/app/components/HackerNewsList/__snapshots__/HackerNewsList.spec.jsx.snap
+++ b/app/components/HackerNewsList/__snapshots__/HackerNewsList.spec.jsx.snap
@@ -5,7 +5,7 @@ exports[`<HackerNewsList /> should match snapshot when render default 1`] = `
   className="HackerNewsList"
 >
   <LoadingIndicator
-    active={true}
+    active={false}
     style={
       Object {
         "left": "calc(50% - 24px)",
@@ -14,6 +14,11 @@ exports[`<HackerNewsList /> should match snapshot when render default 1`] = `
       }
     }
   />
+  <p
+    className="HackerNewsList__noti"
+  >
+    There are no items to show.
+  </p>
 </ul>
 `;
 

--- a/app/components/HackerNewsList/index.jsx
+++ b/app/components/HackerNewsList/index.jsx
@@ -9,20 +9,25 @@ import './HackerNewsList.scss';
 
 const propTypes = {
   feeds: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  isFetching: PropTypes.bool,
 };
 
 const defaultProps = {
   feeds: Immutable.List(),
+  isFetching: false,
 };
 
-function HackerNewsList({ feeds }) {
+function HackerNewsList({ feeds, isFetching }) {
+  const haveNoItems = !isFetching && feeds.size === 0;
+
   return (
     <ul className="HackerNewsList">
       <LoadingIndicator
-        active={!feeds.size}
+        active={isFetching}
         style={{ position: 'absolute', left: 'calc(50% - 24px)', marginTop: '10px' }}
       />
-      {feeds.map((feed, index) => (
+      {haveNoItems && <p className="HackerNewsList__noti">There are no items to show.</p>}
+      {!isFetching && feeds.map((feed, index) => (
         <li className="HackerNewsList__item" key={feed.get('id')}>
           <span className="HackerNewsList__index">{index + 1}</span>
           <HackerNewsListItem {...feed.toJS()} />

--- a/app/components/Pagination/Pagination.spec.jsx
+++ b/app/components/Pagination/Pagination.spec.jsx
@@ -9,6 +9,18 @@ describe('<Pagination />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should have .Pagination__button--disabled when props.currentPage === 1', () => {
+    const wrapper = shallow(<Pagination currentPage={1} />);
+    const button = wrapper.find('.Pagination__button--disabled');
+    expect(button.props()['data-button']).toBe('prev');
+  });
+
+  it('should have .Pagination__button--disabled when props.currentPage === 10', () => {
+    const wrapper = shallow(<Pagination currentPage={10} />);
+    const button = wrapper.find('.Pagination__button--disabled');
+    expect(button.props()['data-button']).toBe('next');
+  });
+
   it('should calls onPaginate with currentPage - 1 when simulate prev button click event', () => {
     const currentPage = 3;
     const onPaginate = jest.fn();
@@ -20,8 +32,8 @@ describe('<Pagination />', () => {
       />
     ));
     wrapper.find('.Pagination__button').at(0).simulate('click');
-    expect(onPaginate.mock.calls.length).toBe(1);
-    expect(onPaginate.mock.calls[0]).toEqual([currentPage - 1]);
+    expect(onPaginate).toHaveBeenCalledTimes(1);
+    expect(onPaginate).toHaveBeenCalledWith(currentPage - 1);
   });
 
   it('should calls onPaginate with currentPage + 1 when simulate next button click event', () => {
@@ -35,7 +47,7 @@ describe('<Pagination />', () => {
       />
     ));
     wrapper.find('.Pagination__button').at(1).simulate('click');
-    expect(onPaginate.mock.calls.length).toBe(1);
-    expect(onPaginate.mock.calls[0]).toEqual([currentPage + 1]);
+    expect(onPaginate).toHaveBeenCalledTimes(1);
+    expect(onPaginate).toHaveBeenCalledWith(currentPage + 1);
   });
 });

--- a/app/components/Pagination/__snapshots__/Pagination.spec.jsx.snap
+++ b/app/components/Pagination/__snapshots__/Pagination.spec.jsx.snap
@@ -9,6 +9,7 @@ exports[`<Pagination /> should match snapshot when render default 1`] = `
   >
     <button
       className="Pagination__button Pagination__button--disabled"
+      data-button="prev"
       disabled={true}
       onClick={[Function]}
       type="button"
@@ -16,9 +17,13 @@ exports[`<Pagination /> should match snapshot when render default 1`] = `
       &lt;
        Prev
     </button>
+    1
+     / 10
      
     <button
       className="Pagination__button"
+      data-button="next"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >

--- a/app/components/Pagination/index.jsx
+++ b/app/components/Pagination/index.jsx
@@ -16,9 +16,14 @@ const defaultProps = {
 
 function Pagination({ currentPage, onPaginate }) {
   const prevDisabled = currentPage === 1;
+  const nextDisabled = currentPage === 10;
 
   const prevButtonClassName = cx('Pagination__button', {
     'Pagination__button--disabled': prevDisabled,
+  });
+
+  const nextButtonClassName = cx('Pagination__button', {
+    'Pagination__button--disabled': nextDisabled,
   });
 
   return (
@@ -26,15 +31,19 @@ function Pagination({ currentPage, onPaginate }) {
       <div className="Pagination__inner">
         <button
           className={prevButtonClassName}
+          data-button="prev"
           disabled={prevDisabled}
           type="button"
           onClick={() => onPaginate(currentPage - 1)}
         >
           {'<'} Prev
         </button>
+        {currentPage} / 10
         {' '}
         <button
-          className="Pagination__button"
+          className={nextButtonClassName}
+          data-button="next"
+          disabled={nextDisabled}
           type="button"
           onClick={() => onPaginate(currentPage + 1)}
         >

--- a/app/containers/HackerNewsListContainer.jsx
+++ b/app/containers/HackerNewsListContainer.jsx
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 
 import HackerNewsList from 'components/HackerNewsList';
-import { getFeeds } from 'store/selectors';
+import { getFeeds, getIsFetching } from 'store/selectors';
 
 const mapStateToProps = (state, props) => ({
   feeds: getFeeds(state, props),
+  isFetching: getIsFetching(state),
 });
 
 export default connect(mapStateToProps)(HackerNewsList);

--- a/app/store/__tests__/reducers/isFetching.spec.js
+++ b/app/store/__tests__/reducers/isFetching.spec.js
@@ -1,0 +1,62 @@
+import * as ACTIONS from 'store/actionTypes';
+import isFetching from 'store/isFetching';
+
+describe('isFetching reducer', () => {
+  it('should return the initial state', () => {
+    expect(isFetching(undefined, {})).toBe(false);
+  });
+
+  it('should handle HACKER_COMMENTS_FETCH_REQUEST', () => {
+    expect(isFetching(false, {
+      type: ACTIONS.HACKER_COMMENTS_FETCH_REQUEST,
+    })).toBe(true);
+  });
+
+  it('should handle HACKER_COMMENTS_FETCH_SUCCESS', () => {
+    expect(isFetching(true, {
+      type: ACTIONS.HACKER_COMMENTS_FETCH_SUCCESS,
+    })).toBe(false);
+  });
+
+  it('should handle HACKER_COMMENTS_FETCH_FAILURE', () => {
+    expect(isFetching(true, {
+      type: ACTIONS.HACKER_COMMENTS_FETCH_FAILURE,
+    })).toBe(false);
+  });
+
+  it('should handle HACKER_NEWS_FETCH_REQUEST', () => {
+    expect(isFetching(false, {
+      type: ACTIONS.HACKER_NEWS_FETCH_REQUEST,
+    })).toBe(true);
+  });
+
+  it('should handle HACKER_NEWS_FETCH_SUCCESS', () => {
+    expect(isFetching(true, {
+      type: ACTIONS.HACKER_NEWS_FETCH_SUCCESS,
+    })).toBe(false);
+  });
+
+  it('should handle HACKER_NEWS_FETCH_FAILURE', () => {
+    expect(isFetching(true, {
+      type: ACTIONS.HACKER_NEWS_FETCH_FAILURE,
+    })).toBe(false);
+  });
+
+  it('should handle HACKER_USER_FETCH_REQUEST', () => {
+    expect(isFetching(false, {
+      type: ACTIONS.HACKER_USER_FETCH_REQUEST,
+    })).toBe(true);
+  });
+
+  it('should handle HACKER_USER_FETCH_SUCCESS', () => {
+    expect(isFetching(true, {
+      type: ACTIONS.HACKER_USER_FETCH_SUCCESS,
+    })).toBe(false);
+  });
+
+  it('should handle HACKER_USER_FETCH_FAILURE', () => {
+    expect(isFetching(true, {
+      type: ACTIONS.HACKER_USER_FETCH_FAILURE,
+    })).toBe(false);
+  });
+});

--- a/app/store/__tests__/selectors.spec.js
+++ b/app/store/__tests__/selectors.spec.js
@@ -9,6 +9,7 @@ describe('selectors', () => {
       posts: Immutable.Map(),
     },
     currentPage: 1,
+    isFetching: false,
     items: {
       ask: {},
       jobs: {},
@@ -25,6 +26,10 @@ describe('selectors', () => {
 
   it('should select currentPage', () => {
     expect(selectors.getCurrentPage(state)).toBe(state.get('currentPage'));
+  });
+
+  it('should select isFetching', () => {
+    expect(selectors.getIsFetching(state)).toBe(state.get('isFetching'));
   });
 
   it('should select items', () => {

--- a/app/store/isFetching/index.js
+++ b/app/store/isFetching/index.js
@@ -1,0 +1,21 @@
+import * as ACTIONS from '../actionTypes';
+
+function itemsReducer(state = false, action) {
+  switch (action.type) {
+    case ACTIONS.HACKER_COMMENTS_FETCH_REQUEST:
+    case ACTIONS.HACKER_NEWS_FETCH_REQUEST:
+    case ACTIONS.HACKER_USER_FETCH_REQUEST:
+      return true;
+    case ACTIONS.HACKER_COMMENTS_FETCH_SUCCESS:
+    case ACTIONS.HACKER_COMMENTS_FETCH_FAILURE:
+    case ACTIONS.HACKER_NEWS_FETCH_SUCCESS:
+    case ACTIONS.HACKER_NEWS_FETCH_FAILURE:
+    case ACTIONS.HACKER_USER_FETCH_SUCCESS:
+    case ACTIONS.HACKER_USER_FETCH_FAILURE:
+      return false;
+    default:
+      return state;
+  }
+}
+
+export default itemsReducer;

--- a/app/store/rootReducer.js
+++ b/app/store/rootReducer.js
@@ -4,6 +4,7 @@ import { routerReducer } from 'react-router-redux';
 import byId from './byId';
 import comments from './comments';
 import currentPage from './currentPage';
+import isFetching from './isFetching';
 import items from './items';
 import user from './user';
 
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   byId,
   comments,
   currentPage,
+  isFetching,
   items,
   user,
   router: routerReducer,

--- a/app/store/selectors.js
+++ b/app/store/selectors.js
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect';
 
 export const getById = state => state.get('byId');
 export const getCurrentPage = state => state.get('currentPage');
+export const getIsFetching = state => state.get('isFetching');
 export const getItems = state => state.get('items');
 export const getUser = state => state.get('user');
 


### PR DESCRIPTION
Related to https://github.com/tastejs/hacker-news-pwas/pull/126#issuecomment-357396487

This pull request change pagination UX.

Currently, I use hacker news API as [Unofficial Hacker News API](https://github.com/cheeaun/node-hnapi) created by [cheeaun](https://github.com/cheeaun). but this not returns max pagination number related to a specific topic. but as you can see [this issue](https://github.com/cheeaun/node-hnapi/issues/29#issue-274183021), whatever topic is, max page number is 10. So, I alternatively use this number to change pagination UX.

- https://github.com/taehwanno/hnpwa-react/blob/e8cdbe02d7fd4c17cbd7c6ab94b615863a728dc9/app/components/Pagination/index.jsx#L41
- https://github.com/taehwanno/hnpwa-react/blob/78a16bd944bab17a0e1caaaf32424913af465682/app/components/HackerNewsList/index.jsx#L29

